### PR TITLE
[add] http/rate-limit/simple example

### DIFF
--- a/conf/http/rate-limit/simple.conf
+++ b/conf/http/rate-limit/simple.conf
@@ -1,0 +1,33 @@
+load_module modules/ngx_http_js_module.so;
+
+error_log /dev/stdout debug;
+
+events {  }
+
+http {
+  js_path "/etc/nginx/njs/";
+  js_import main from http/rate-limit/simple.js;
+  # optionally set timeout so NJS resets and deletes all data for ratelimit counters
+  js_shared_dict_zone zone=kv:1M timeout=3600s evict;
+
+  server {
+    listen 80;
+    server_name www.example.com;
+    # access_log off;
+    js_var $rl_zone_name kv;          # shared dict zone name; requred variable
+    js_var $rl_windows_ms 30000;      # optional window in miliseconds; default 1 minute window if not set
+    js_var $rl_limit 10;              # optional limit for the window; default 10 requests if not set
+    js_var $rl_key $remote_addr;      # rate limit key; default remote_addr if not set
+    js_set $rl_result main.ratelimit; # call ratelimit function that returns retry-after value if limit is exceeded
+
+    location = / {
+      # test rate limit result
+      if ($rl_result != "0") {
+        add_header Retry-After $rl_result always;
+        return 429 "Too Many Requests.";
+      }
+      # Your normal processing here
+      return 200 "hello world";
+    }
+  }
+}

--- a/njs/http/rate-limit/simple.js
+++ b/njs/http/rate-limit/simple.js
@@ -1,0 +1,60 @@
+const defaultResponse = "0";
+
+/**
+ * Applies rate limiting logic for the request.
+ *
+ * @param {Object} r - The request object.
+ * @returns {string} - The retry-after value in seconds as a string. '0' means no reate limit.
+ */
+function ratelimit(r) {
+    const zone = r.variables['rl_zone_name'];
+    const kv = zone && ngx.shared && ngx.shared[zone];
+    if (!kv) {
+        r.log(`ratelimit: ${zone} js_shared_dict_zone not found`);
+        return defaultResponse;
+    }
+
+    const key = r.variables['rl_key'] || r.variables['remote_addr'];
+    const window = Number(r.variables['rl_windows_ms']) || 60000;
+    const limit = Number(r.variables['rl_limit']) || 10;
+    const now = Date.now();
+
+    let requestData = kv.get(key);
+    if (requestData === undefined || requestData.length === 0) {
+        r.log(`ratelimit: setting initial value for ${key}`);
+        requestData = { timestamp: now, count: 1 }
+        kv.set(key, JSON.stringify(requestData));
+        return defaultResponse;
+    }
+    try {
+        requestData = JSON.parse(requestData);
+    } catch (e) {
+        r.log(`ratelimit: failed to parse value for ${key}`);
+        requestData = { timestamp: now, count: 1 }
+        kv.set(key, JSON.stringify(requestData));
+        return defaultResponse;
+    }
+    if (!requestData) {
+        // remember the first request
+        r.log(`ratelimit: value for ${key} was not set`);
+        requestData = { timestamp: now, count: 1 }
+        kv.set(key, JSON.stringify(requestData));
+        return defaultResponse;
+    }
+    if (now - requestData.timestamp >= window) {
+        requestData.timestamp = now;
+        requestData.count = 1;
+    } else {
+        requestData.count++;
+    }
+    const elapsed = now - requestData.timestamp;
+    r.log(`limit: ${limit} window: ${window} elapsed: ${elapsed}  count: ${requestData.count} timestamp: ${requestData.timestamp}`)
+    let retryAfter = 0;
+    if (requestData.count > limit) {
+        retryAfter = Math.ceil((window - elapsed) / 1000);
+    }
+    kv.set(key, JSON.stringify(requestData));
+    return retryAfter.toString();
+}
+
+export default { ratelimit };


### PR DESCRIPTION
This example demonstrates a simple rate-limit algorithm based on counters and uses Shared Dictionary Zone functionality (requires [njs v.0.8.0](https://nginx.org/en/docs/njs/changes.html#njs0.8.0)) to store data